### PR TITLE
ci: handle when grep exits with code 1 in test-summary action

### DIFF
--- a/.github/actions/test-summary/action.yml
+++ b/.github/actions/test-summary/action.yml
@@ -60,7 +60,7 @@ runs:
 
         echo "$table" > $GITHUB_STEP_SUMMARY
 
-        count=$(echo "$table" | grep -o '❌' | wc -l)
+        count=$(echo "$table" | { grep -o '❌' || true; } | wc -l)
 
         # Keep at this indentation level for heredoc.
         fail_summary=$(cat <<EOF


### PR DESCRIPTION
To do:
- [X] No comment appears when all tests pass.
- [X] Comment is added and failed count is correct.
- [x] Comment is removed when tests pass again (after page refresh; GitHub UI bug).